### PR TITLE
feat(sgx): replace sendBundle namespace

### DIFF
--- a/server/node_nosgx.go
+++ b/server/node_nosgx.go
@@ -18,6 +18,7 @@ func NewNode(log *zap.SugaredLogger, uri string, jobC chan *SimRequest, numWorke
 		jobC:       jobC,
 		numWorkers: numWorkers,
 		client:     &http.Client{},
+		enclave:    false,
 	}
 	return node, nil
 }


### PR DESCRIPTION
We might want to consider hiding this behaviour behind a startup argument, I could imagine running the `bytes.Replace` method on 8MB payloads is taking a hit on performance.