### PR TITLE
fast-track queue (1:1 with high-prio)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 name: Checks
 jobs:
   lint:
@@ -7,7 +12,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.19
+        go-version: ^1.20
       id: go
 
     - name: Checkout code
@@ -31,7 +36,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.19
+        go-version: ^1.20
       id: go
 
     - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ARG VERSION
 WORKDIR /build
 ADD . /build/

--- a/Dockerfile.sgx
+++ b/Dockerfile.sgx
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ARG VERSION
 WORKDIR /build
 ADD . /build/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flashbots/prio-load-balancer
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alicebob/miniredis v2.5.0+incompatible

--- a/main.go
+++ b/main.go
@@ -107,8 +107,8 @@ func main() {
 		for {
 			time.Sleep(10 * time.Second)
 			log.Infow("goroutines:", "numGoroutines", runtime.NumGoroutine())
-			lenHighPrio, lenLowPrio := srv.QueueSize()
-			log.Infow("prioQueue size:", "highPrio", lenHighPrio, "lowPrio", lenLowPrio)
+			lenFastTrack, lenHighPrio, lenLowPrio := srv.QueueSize()
+			log.Infow("prioQueue size:", "fastTrack", lenFastTrack, "highPrio", lenHighPrio, "lowPrio", lenLowPrio)
 		}
 	}()
 

--- a/server/consts.go
+++ b/server/consts.go
@@ -7,11 +7,13 @@ import (
 )
 
 var (
-	JobChannelBuffer      = GetEnvInt("JOB_CHAN_BUFFER", 2)          // buffer for JobC in backends (for transporting jobs from server -> backend node)
-	RequestMaxTries       = GetEnvInt("RETRIES_MAX", 3)              // 3 tries means it will be retried 2 additional times, and on third error would fail
-	MaxQueueItemsHighPrio = GetEnvInt("ITEMS_HIGHPRIO_MAX", 0)       // Max number of items in high-prio queue. 0 means no limit.
-	MaxQueueItemsLowPrio  = GetEnvInt("ITEMS_LOWPRIO_MAX", 0)        // Max number of items in low-prio queue. 0 means no limit.
-	PayloadMaxBytes       = GetEnvInt("PAYLOAD_MAX_KB", 8192) * 1024 // Max payload size in bytes. If a payload sent to the webserver is larger, it returns "400 Bad Request".
+	JobChannelBuffer = GetEnvInt("JOB_CHAN_BUFFER", 2)          // buffer for JobC in backends (for transporting jobs from server -> backend node)
+	RequestMaxTries  = GetEnvInt("RETRIES_MAX", 3)              // 3 tries means it will be retried 2 additional times, and on third error would fail
+	PayloadMaxBytes  = GetEnvInt("PAYLOAD_MAX_KB", 8192) * 1024 // Max payload size in bytes. If a payload sent to the webserver is larger, it returns "400 Bad Request".
+
+	MaxQueueItemsFastTrack = GetEnvInt("ITEMS_FASTTRACK_MAX", 0) // Max number of items in fast-track queue. 0 means no limit.
+	MaxQueueItemsHighPrio  = GetEnvInt("ITEMS_HIGHPRIO_MAX", 0)  // Max number of items in high-prio queue. 0 means no limit.
+	MaxQueueItemsLowPrio   = GetEnvInt("ITEMS_LOWPRIO_MAX", 0)   // Max number of items in low-prio queue. 0 means no limit.
 
 	RequestTimeout       = time.Duration(GetEnvInt("REQUEST_TIMEOUT", 5)) * time.Second       // Time between creation and receive in the node worker, after which a SimRequest will not be processed anymore
 	ServerJobSendTimeout = time.Duration(GetEnvInt("JOB_SEND_TIMEOUT", 2)) * time.Second      // How long the server tries to send a job into the nodepool for processing

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -21,7 +21,7 @@ func TestNode(t *testing.T) {
 	err = node.HealthCheck()
 	require.Nil(t, err, err)
 
-	request := NewSimRequest(true, []byte("foo"))
+	request := NewSimRequest([]byte("foo"), true, false)
 	node.StartWorkers()
 	node.jobC <- request
 	res := <-request.ResponseC
@@ -60,7 +60,7 @@ func TestNodeError(t *testing.T) {
 	require.Equal(t, 479, statusCode)
 
 	// Check failing SimRequest
-	request := NewSimRequest(true, []byte("foo"))
+	request := NewSimRequest([]byte("foo"), true, false)
 	node.StartWorkers()
 	node.jobC <- request
 	res := <-request.ResponseC

--- a/server/nodepool_test.go
+++ b/server/nodepool_test.go
@@ -63,7 +63,7 @@ func TestNodePoolProxy(t *testing.T) {
 	err := gp.AddNode(rpcBackendServer.URL)
 	require.Nil(t, err, err)
 
-	request := NewSimRequest(true, []byte("foo"))
+	request := NewSimRequest([]byte("foo"), true, false)
 
 	gp.JobC <- request
 	res := <-request.ResponseC
@@ -84,7 +84,7 @@ func TestNodePoolWithError(t *testing.T) {
 		http.Error(w, "error", 479)
 	}
 
-	request := NewSimRequest(true, []byte("foo"))
+	request := NewSimRequest([]byte("foo"), true, false)
 	gp.JobC <- request
 	res := <-request.ResponseC
 	require.NotNil(t, res)

--- a/server/queue_test.go
+++ b/server/queue_test.go
@@ -10,14 +10,15 @@ import (
 )
 
 func cloneRequest(req *SimRequest) *SimRequest {
-	return NewSimRequest(req.IsHighPrio, req.Payload)
+	return NewSimRequest(req.Payload, req.IsHighPrio, req.IsFastTrack)
 }
 
 func TestPrioQueueGeneral(t *testing.T) {
-	q := NewPrioQueue(0, 0)
+	q := NewPrioQueue(0, 0, 0)
 
-	taskLowPrio := NewSimRequest(false, []byte("taskLowPrio"))
-	taskHighPrio := NewSimRequest(true, []byte("taskHighPrio"))
+	taskLowPrio := NewSimRequest([]byte("taskLowPrio"), false, false)
+	taskHighPrio := NewSimRequest([]byte("taskHighPrio"), true, false)
+	taskFastTrack := NewSimRequest([]byte("tasFastTrack"), false, true)
 
 	// Ensure queue.Pop is blocking
 	t1 := time.Now()
@@ -27,7 +28,7 @@ func TestPrioQueueGeneral(t *testing.T) {
 	require.NotNil(t, resp)
 	require.True(t, tX >= 100*time.Millisecond)
 
-	// Ensure low prio item is returned last
+	// low prio item is added first, but returned last
 	q.Push(taskLowPrio)
 	q.Push(taskHighPrio)
 	q.Push(cloneRequest(taskHighPrio))
@@ -39,25 +40,35 @@ func TestPrioQueueGeneral(t *testing.T) {
 	q.Push(cloneRequest(taskHighPrio))
 	q.Push(cloneRequest(taskHighPrio))
 	q.Push(cloneRequest(taskHighPrio))
-	q.Push(cloneRequest(taskHighPrio)) // 11
+	q.Push(cloneRequest(taskHighPrio)) // 11x highPrio
+	q.Push(taskFastTrack)
+	q.Push(cloneRequest(taskFastTrack)) // 2x fastTrack
 
+	require.Equal(t, 2, len(q.fastTrack))
 	require.Equal(t, 11, len(q.highPrio))
 	require.Equal(t, 1, len(q.lowPrio))
 
-	for i := 0; i < 11; i++ {
-		resp := q.Pop()
-		require.Equal(t, true, resp.IsHighPrio)
+	// Start popping!
+	// should be: fastTrack -> highPrio -> fastTrack -> highPrio
+	require.Equal(t, true, q.Pop().IsFastTrack)
+	require.Equal(t, true, q.Pop().IsHighPrio)
+	require.Equal(t, true, q.Pop().IsFastTrack)
+	require.Equal(t, true, q.Pop().IsHighPrio)
+
+	// next 9 should all be high-prio
+	for i := 0; i < 9; i++ {
+		require.Equal(t, true, q.Pop().IsHighPrio)
 	}
 
-	resp = q.Pop()
-	require.Equal(t, false, resp.IsHighPrio)
+	// lat one should be low-prio
+	require.Equal(t, false, q.Pop().IsHighPrio)
 	require.Equal(t, 0, len(q.lowPrio))
 	require.Equal(t, 0, len(q.highPrio))
 }
 
 func TestPrioQueueMultipleReaders(t *testing.T) {
-	q := NewPrioQueue(0, 0)
-	taskLowPrio := NewSimRequest(false, []byte("taskLowPrio"))
+	q := NewPrioQueue(0, 0, 0)
+	taskLowPrio := NewSimRequest([]byte("taskLowPrio"), false, false)
 
 	counts := make(map[int]int)
 	resultC := make(chan int, 4)
@@ -99,7 +110,7 @@ func TestPrioQueueMultipleReaders(t *testing.T) {
 }
 
 func TestPrioQueueVarious(t *testing.T) {
-	q := NewPrioQueue(0, 0)
+	q := NewPrioQueue(0, 0, 0)
 	q.Push(nil)
 	require.Equal(t, 0, len(q.highPrio))
 	require.Equal(t, 0, len(q.lowPrio))
@@ -109,8 +120,8 @@ func TestPrioQueueVarious(t *testing.T) {
 
 // Test used for benchmark: single reader
 func _testPrioQueue1(numWorkers, numItems int) *PrioQueue {
-	q := NewPrioQueue(0, 0)
-	taskLowPrio := NewSimRequest(false, []byte("taskLowPrio"))
+	q := NewPrioQueue(0, 0, 0)
+	taskLowPrio := NewSimRequest([]byte("taskLowPrio"), false, false)
 
 	var wg sync.WaitGroup
 

--- a/server/queue_test.go
+++ b/server/queue_test.go
@@ -60,7 +60,7 @@ func TestPrioQueueGeneral(t *testing.T) {
 		require.Equal(t, true, q.Pop().IsHighPrio)
 	}
 
-	// lat one should be low-prio
+	// last one should be low-prio
 	require.Equal(t, false, q.Pop().IsHighPrio)
 	require.Equal(t, 0, len(q.lowPrio))
 	require.Equal(t, 0, len(q.highPrio))

--- a/server/server.go
+++ b/server/server.go
@@ -30,7 +30,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	s := Server{
 		opts:      opts,
 		log:       opts.Log,
-		prioQueue: NewPrioQueue(MaxQueueItemsHighPrio, MaxQueueItemsLowPrio),
+		prioQueue: NewPrioQueue(MaxQueueItemsFastTrack, MaxQueueItemsHighPrio, MaxQueueItemsLowPrio),
 	}
 
 	if s.opts.RedisURI == "" {
@@ -125,6 +125,6 @@ func (s *Server) NumNodeWorkersAlive() int {
 	return res
 }
 
-func (s *Server) QueueSize() (lenHighPrio, lenLowPrio int) {
+func (s *Server) QueueSize() (lenFastTrack, lenHighPrio, lenLowPrio int) {
 	return s.prioQueue.Len()
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -112,6 +112,6 @@ func TestServerJobTimeout(t *testing.T) {
 	resp, _ := http.Post(url, "application/json", bytes.NewBuffer(reqPayloadBytes))
 	require.Nil(t, err, err)
 	require.Equal(t, 500, resp.StatusCode)
-	lenHP, lenLP := s.prioQueue.Len()
-	require.Equal(t, 0, lenHP+lenLP)
+	lenFT, lenHP, lenLP := s.prioQueue.Len()
+	require.Equal(t, 0, lenFT+lenHP+lenLP)
 }

--- a/server/types.go
+++ b/server/types.go
@@ -3,20 +3,24 @@ package server
 import "time"
 
 type SimRequest struct {
-	IsHighPrio bool
-	Payload    []byte
-	ResponseC  chan SimResponse
-	Cancelled  bool
-	CreatedAt  time.Time
-	Tries      int
+	// can be none of, or one of high-prio / fast-track
+	IsHighPrio  bool
+	IsFastTrack bool
+
+	Payload   []byte
+	ResponseC chan SimResponse
+	Cancelled bool
+	CreatedAt time.Time
+	Tries     int
 }
 
-func NewSimRequest(isHighPrio bool, payload []byte) *SimRequest {
+func NewSimRequest(payload []byte, isHighPrio, IsFastTrack bool) *SimRequest {
 	return &SimRequest{
-		IsHighPrio: isHighPrio,
-		Payload:    payload,
-		ResponseC:  make(chan SimResponse, 1),
-		CreatedAt:  time.Now(),
+		Payload:     payload,
+		IsHighPrio:  isHighPrio,
+		IsFastTrack: IsFastTrack,
+		ResponseC:   make(chan SimResponse, 1),
+		CreatedAt:   time.Now(),
 	}
 }
 

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -78,8 +78,9 @@ func (s *Webserver) HandleQueueRequest(w http.ResponseWriter, req *http.Request)
 	}
 
 	// Add new sim request to queue
+	isFastTrack := req.Header.Get("X-Fast-Track") == "true"
 	isHighPrio := req.Header.Get("high_prio") == "true" || req.Header.Get("X-High-Priority") == "true"
-	simReq := NewSimRequest(isHighPrio, body)
+	simReq := NewSimRequest(body, isHighPrio, isFastTrack)
 	wasAdded := s.prioQueue.Push(simReq)
 	if !wasAdded { // queue was full, job not added
 		s.log.Error("Couldn't add request, queue is full")
@@ -87,8 +88,8 @@ func (s *Webserver) HandleQueueRequest(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	lenHighPrio, lenLowPrio := s.prioQueue.Len()
-	s.log.Infow("Request added to queue. prioQueue size:", "requestIsHighPrio", isHighPrio, "highPrio", lenHighPrio, "lowPrio", lenLowPrio)
+	lenFastTrack, lenHighPrio, lenLowPrio := s.prioQueue.Len()
+	s.log.Infow("Request added to queue. prioQueue size:", "requestIsHighPrio", isHighPrio, "requestIsFastTrack", isFastTrack, "fastTrack", lenFastTrack, "highPrio", lenHighPrio, "lowPrio", lenLowPrio)
 
 	// Wait for response or cancel
 	for {

--- a/server/webserver_test.go
+++ b/server/webserver_test.go
@@ -19,7 +19,7 @@ import (
 func TestWebserver(t *testing.T) {
 	resetTestRedis()
 
-	prioQueue := NewPrioQueue(0, 0)
+	prioQueue := NewPrioQueue(0, 0, 0)
 	nodePool := NewNodePool(testLog, redisTestState, 1)
 	webserver := NewWebserver(testLog, ":12345", prioQueue, nodePool)
 
@@ -100,7 +100,7 @@ func TestWebserverSim(t *testing.T) {
 	mockNodeBackend := testutils.NewMockNodeBackend()
 	mockNodeServer := httptest.NewServer(http.HandlerFunc(mockNodeBackend.Handler))
 
-	prioQueue := NewPrioQueue(0, 0)
+	prioQueue := NewPrioQueue(0, 0, 0)
 	nodePool := NewNodePool(testLog, nil, 1)
 	nodePool.AddNode(mockNodeServer.URL)
 	webserver := NewWebserver(testLog, ":12345", prioQueue, nodePool)


### PR DESCRIPTION
Adds a third queue to allow fast-tracking requests. It pops items round-robin with high-prio (1:1).

Requests are fast-tracked when using `X-Fast-Track=true` header.