### PR TITLE
URL path support - groundwork for non-jsonrpc HTTP proxying

### DIFF
--- a/server/node_test.go
+++ b/server/node_test.go
@@ -21,7 +21,7 @@ func TestNode(t *testing.T) {
 	err = node.HealthCheck()
 	require.Nil(t, err, err)
 
-	request := NewSimRequest("1", []byte("foo"), true, false)
+	request := NewSimRequest("1", []byte("foo"), true, false, "")
 	node.StartWorkers()
 	node.jobC <- request
 	res := <-request.ResponseC
@@ -55,12 +55,12 @@ func TestNodeError(t *testing.T) {
 	require.Contains(t, err.Error(), "479")
 
 	// Check failing ProxyRequest
-	_, statusCode, err := node.ProxyRequest([]byte("net_version"), 3*time.Second)
+	_, statusCode, err := node.ProxyRequest("", []byte("net_version"), 3*time.Second)
 	require.NotNil(t, err, err)
 	require.Equal(t, 479, statusCode)
 
 	// Check failing SimRequest
-	request := NewSimRequest("1", []byte("foo"), true, false)
+	request := NewSimRequest("1", []byte("foo"), true, false, "")
 	node.StartWorkers()
 	node.jobC <- request
 	res := <-request.ResponseC

--- a/server/nodepool_test.go
+++ b/server/nodepool_test.go
@@ -63,7 +63,7 @@ func TestNodePoolProxy(t *testing.T) {
 	err := gp.AddNode(rpcBackendServer.URL)
 	require.Nil(t, err, err)
 
-	request := NewSimRequest("1", []byte("foo"), true, false)
+	request := NewSimRequest("1", []byte("foo"), true, false, "")
 
 	gp.JobC <- request
 	res := <-request.ResponseC
@@ -84,7 +84,7 @@ func TestNodePoolWithError(t *testing.T) {
 		http.Error(w, "error", 479)
 	}
 
-	request := NewSimRequest("1", []byte("foo"), true, false)
+	request := NewSimRequest("1", []byte("foo"), true, false, "")
 	gp.JobC <- request
 	res := <-request.ResponseC
 	require.NotNil(t, res)

--- a/server/queue_test.go
+++ b/server/queue_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 func cloneRequest(req *SimRequest) *SimRequest {
-	return NewSimRequest("1", req.Payload, req.IsHighPrio, req.IsFastTrack)
+	return NewSimRequest("1", req.Payload, req.IsHighPrio, req.IsFastTrack, "")
 }
 
 func fillQueue(t *testing.T, q *PrioQueue) {
 	t.Helper()
 
-	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false)
-	taskHighPrio := NewSimRequest("1", []byte("taskHighPrio"), true, false)
-	taskFastTrack := NewSimRequest("1", []byte("tasFastTrack"), false, true)
+	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false, "")
+	taskHighPrio := NewSimRequest("1", []byte("taskHighPrio"), true, false, "")
+	taskFastTrack := NewSimRequest("1", []byte("tasFastTrack"), false, true, "")
 
 	q.Push(taskLowPrio)
 	q.Push(taskHighPrio)
@@ -46,7 +46,7 @@ func fillQueue(t *testing.T, q *PrioQueue) {
 
 func TestQueueBlockingPop(t *testing.T) {
 	q := NewPrioQueue(0, 0, 0, 2, false)
-	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false)
+	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false, "")
 
 	// Ensure queue.Pop is blocking
 	t1 := time.Now()
@@ -102,7 +102,7 @@ func TestQueuePopping(t *testing.T) {
 
 func TestPrioQueueMultipleReaders(t *testing.T) {
 	q := NewPrioQueue(0, 0, 0, 2, false)
-	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false)
+	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false, "")
 
 	counts := make(map[int]int)
 	resultC := make(chan int, 4)
@@ -155,7 +155,7 @@ func TestPrioQueueVarious(t *testing.T) {
 // Test used for benchmark: single reader
 func _testPrioQueue1(numWorkers, numItems int) *PrioQueue {
 	q := NewPrioQueue(0, 0, 0, 2, false)
-	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false)
+	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false, "")
 
 	var wg sync.WaitGroup
 

--- a/server/types.go
+++ b/server/types.go
@@ -8,16 +8,19 @@ type SimRequest struct {
 	IsHighPrio  bool
 	IsFastTrack bool
 
-	Payload   []byte
+	TargetPath string
+	Payload    []byte
+
 	ResponseC chan SimResponse
 	Cancelled bool
 	CreatedAt time.Time
 	Tries     int
 }
 
-func NewSimRequest(id string, payload []byte, isHighPrio, IsFastTrack bool) *SimRequest {
+func NewSimRequest(id string, payload []byte, isHighPrio, IsFastTrack bool, targetPath string) *SimRequest {
 	return &SimRequest{
 		ID:          id,
+		TargetPath:  targetPath,
 		Payload:     payload,
 		IsHighPrio:  isHighPrio,
 		IsFastTrack: IsFastTrack,

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -75,8 +75,9 @@ func (s *Webserver) HandleQueueRequest(w http.ResponseWriter, req *http.Request)
 	defer req.Body.Close()
 
 	// Allow single `X-Request-ID:...` log field via header
-	reqID := req.Header.Get("X-Request-ID")
 	log := s.log
+
+	reqID := req.Header.Get("X-Request-ID")
 	if reqID != "" {
 		log = s.log.With("reqID", reqID)
 	}
@@ -102,7 +103,9 @@ func (s *Webserver) HandleQueueRequest(w http.ResponseWriter, req *http.Request)
 	// Add new sim request to queue
 	isFastTrack := req.Header.Get("X-Fast-Track") == "true"
 	isHighPrio := req.Header.Get("high_prio") == "true" || req.Header.Get("X-High-Priority") == "true"
-	simReq := NewSimRequest(reqID, body, isHighPrio, isFastTrack)
+	targetPath := req.Header.Get("X-Target-Path")
+
+	simReq := NewSimRequest(reqID, body, isHighPrio, isFastTrack, targetPath)
 	wasAdded := s.prioQueue.Push(simReq)
 	if !wasAdded { // queue was full, job not added
 		log.Error("Couldn't add request, queue is full")


### PR DESCRIPTION
Add URL path support for forwarding plain HTTP requests (i.e. non-jsonrpc requests)

Allow the request to specify target path with `X-Target-Path` header.

Tasks:
* [x] Implement path support
* [ ] Tests