### PR TITLE
fix: request cancellation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Install Go
-      uses: actions/checkout@v5
+      uses: actions/setup-go@v5
       with:
         go-version: ^1.22
       id: go
@@ -42,14 +42,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ^1.22
       id: go
-
-    - name: Checkout code
-      uses: actions/checkout@v2
 
     - name: Test
       run: make test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,14 +9,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ^1.22
         id: go
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Install gofumpt
         run: go install mvdan.cc/gofumpt@v0.4.0

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ^1.22
         id: go
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install gofumpt
         run: go install mvdan.cc/gofumpt@v0.4.0

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,47 +9,47 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.22
-      id: go
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.22
+        id: go
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Install gofumpt
-      run: go install mvdan.cc/gofumpt@v0.4.0
+      - name: Install gofumpt
+        run: go install mvdan.cc/gofumpt@v0.4.0
 
-    - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
 
-    # - name: Install golangci-lint
-    #   run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+      # - name: Install golangci-lint
+      #   run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
-    - name: Lint
-      run: make lint
+      - name: Lint
+        run: make lint
 
-    - name: Build
-      run: make build build-tee
+      - name: Build
+        run: make build build-tee
 
-    - name: Ensure go mod tidy runs without changes
-      run: |
-        go mod tidy
-        git diff-index HEAD
-        git diff-index --quiet HEAD
+      - name: Ensure go mod tidy runs without changes
+        run: |
+          go mod tidy
+          git diff-index HEAD
+          git diff-index --quiet HEAD
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.22
-      id: go
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.22
+        id: go
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Test
-      run: make test
+      - name: Test
+        run: make test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,47 +9,47 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Install Go
+      uses: actions/checkout@v5
+      with:
+        go-version: ^1.22
+      id: go
 
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ^1.22
-        id: go
+    - name: Install gofumpt
+      run: go install mvdan.cc/gofumpt@v0.4.0
 
-      - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@v0.4.0
+    - name: Install staticcheck
+      run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
 
-      - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
+    # - name: Install golangci-lint
+    #   run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
-      # - name: Install golangci-lint
-      #   run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+    - name: Lint
+      run: make lint
 
-      - name: Lint
-        run: make lint
+    - name: Build
+      run: make build build-tee
 
-      - name: Build
-        run: make build build-tee
-
-      - name: Ensure go mod tidy runs without changes
-        run: |
-          go mod tidy
-          git diff-index HEAD
-          git diff-index --quiet HEAD
+    - name: Ensure go mod tidy runs without changes
+      run: |
+        go mod tidy
+        git diff-index HEAD
+        git diff-index --quiet HEAD
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.22
-        id: go
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.22
+      id: go
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
 
-      - name: Test
-        run: make test
+    - name: Test
+      run: make test

--- a/.github/workflows/release-tee.yml
+++ b/.github/workflows/release-tee.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get tag version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get tag version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -264,5 +264,3 @@ Possibly
 ## License
 
 The code in this project is free software under the [MIT License](LICENSE).
-
-

--- a/README.md
+++ b/README.md
@@ -264,3 +264,5 @@ Possibly
 ## License
 
 The code in this project is free software under the [MIT License](LICENSE).
+
+

--- a/server/node.go
+++ b/server/node.go
@@ -28,7 +28,7 @@ type Node struct {
 
 func (n *Node) HealthCheck() error {
 	payload := `{"jsonrpc":"2.0","method":"net_version","params":[],"id":123}`
-	_, _, err := n.ProxyRequest([]byte(payload), 5*time.Second)
+	_, _, err := n.ProxyRequest(context.Background(), []byte(payload), 5*time.Second)
 	return err
 }
 
@@ -60,7 +60,7 @@ func (n *Node) startProxyWorker(id int32, cancelContext context.Context) {
 
 			req.Tries += 1
 			timeBeforeProxy := time.Now().UTC()
-			payload, statusCode, err := n.ProxyRequest(req.Payload, ProxyRequestTimeout)
+			payload, statusCode, err := n.ProxyRequest(req.Context, req.Payload, ProxyRequestTimeout)
 			requestDuration := time.Since(timeBeforeProxy)
 			_log = _log.With("requestDurationUS", requestDuration.Microseconds())
 			if err != nil {
@@ -117,7 +117,7 @@ func (n *Node) StopWorkersAndWait() {
 	}
 }
 
-func (n *Node) ProxyRequest(payload []byte, timeout time.Duration) (resp []byte, statusCode int, err error) {
+func (n *Node) ProxyRequest(ctx context.Context, payload []byte, timeout time.Duration) (resp []byte, statusCode int, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", n.URI, bytes.NewBuffer(payload))

--- a/server/node.go
+++ b/server/node.go
@@ -118,9 +118,9 @@ func (n *Node) StopWorkersAndWait() {
 }
 
 func (n *Node) ProxyRequest(ctx context.Context, payload []byte, timeout time.Duration) (resp []byte, statusCode int, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctxx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", n.URI, bytes.NewBuffer(payload))
+	httpReq, err := http.NewRequestWithContext(ctxx, "POST", n.URI, bytes.NewBuffer(payload))
 	if err != nil {
 		return resp, statusCode, errors.Wrap(err, "creating proxy request failed")
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,7 +22,7 @@ func TestNode(t *testing.T) {
 	err = node.HealthCheck()
 	require.Nil(t, err, err)
 
-	request := NewSimRequest("1", []byte("foo"), true, false)
+	request := NewSimRequest(context.Background(), "1", []byte("foo"), true, false)
 	node.StartWorkers()
 	node.jobC <- request
 	res := <-request.ResponseC
@@ -55,12 +56,12 @@ func TestNodeError(t *testing.T) {
 	require.Contains(t, err.Error(), "479")
 
 	// Check failing ProxyRequest
-	_, statusCode, err := node.ProxyRequest([]byte("net_version"), 3*time.Second)
+	_, statusCode, err := node.ProxyRequest(context.Background(), []byte("net_version"), 3*time.Second)
 	require.NotNil(t, err, err)
 	require.Equal(t, 479, statusCode)
 
 	// Check failing SimRequest
-	request := NewSimRequest("1", []byte("foo"), true, false)
+	request := NewSimRequest(context.Background(), "1", []byte("foo"), true, false)
 	node.StartWorkers()
 	node.jobC <- request
 	res := <-request.ResponseC

--- a/server/nodepool_test.go
+++ b/server/nodepool_test.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,7 +64,7 @@ func TestNodePoolProxy(t *testing.T) {
 	err := gp.AddNode(rpcBackendServer.URL)
 	require.Nil(t, err, err)
 
-	request := NewSimRequest("1", []byte("foo"), true, false)
+	request := NewSimRequest(context.Background(), "1", []byte("foo"), true, false)
 
 	gp.JobC <- request
 	res := <-request.ResponseC
@@ -84,7 +85,7 @@ func TestNodePoolWithError(t *testing.T) {
 		http.Error(w, "error", 479)
 	}
 
-	request := NewSimRequest("1", []byte("foo"), true, false)
+	request := NewSimRequest(context.Background(), "1", []byte("foo"), true, false)
 	gp.JobC <- request
 	res := <-request.ResponseC
 	require.NotNil(t, res)

--- a/server/queue_test.go
+++ b/server/queue_test.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -11,15 +12,15 @@ import (
 )
 
 func cloneRequest(req *SimRequest) *SimRequest {
-	return NewSimRequest("1", req.Payload, req.IsHighPrio, req.IsFastTrack)
+	return NewSimRequest(context.Background(), "1", req.Payload, req.IsHighPrio, req.IsFastTrack)
 }
 
 func fillQueue(t *testing.T, q *PrioQueue) {
 	t.Helper()
 
-	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false)
-	taskHighPrio := NewSimRequest("1", []byte("taskHighPrio"), true, false)
-	taskFastTrack := NewSimRequest("1", []byte("tasFastTrack"), false, true)
+	taskLowPrio := NewSimRequest(context.Background(), "1", []byte("taskLowPrio"), false, false)
+	taskHighPrio := NewSimRequest(context.Background(), "1", []byte("taskHighPrio"), true, false)
+	taskFastTrack := NewSimRequest(context.Background(), "1", []byte("tasFastTrack"), false, true)
 
 	q.Push(taskLowPrio)
 	q.Push(taskHighPrio)
@@ -46,7 +47,7 @@ func fillQueue(t *testing.T, q *PrioQueue) {
 
 func TestQueueBlockingPop(t *testing.T) {
 	q := NewPrioQueue(0, 0, 0, 2, false)
-	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false)
+	taskLowPrio := NewSimRequest(context.Background(), "1", []byte("taskLowPrio"), false, false)
 
 	// Ensure queue.Pop is blocking
 	t1 := time.Now()
@@ -102,7 +103,7 @@ func TestQueuePopping(t *testing.T) {
 
 func TestPrioQueueMultipleReaders(t *testing.T) {
 	q := NewPrioQueue(0, 0, 0, 2, false)
-	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false)
+	taskLowPrio := NewSimRequest(context.Background(), "1", []byte("taskLowPrio"), false, false)
 
 	counts := make(map[int]int)
 	resultC := make(chan int, 4)
@@ -155,7 +156,7 @@ func TestPrioQueueVarious(t *testing.T) {
 // Test used for benchmark: single reader
 func _testPrioQueue1(numWorkers, numItems int) *PrioQueue {
 	q := NewPrioQueue(0, 0, 0, 2, false)
-	taskLowPrio := NewSimRequest("1", []byte("taskLowPrio"), false, false)
+	taskLowPrio := NewSimRequest(context.Background(), "1", []byte("taskLowPrio"), false, false)
 
 	var wg sync.WaitGroup
 

--- a/server/types.go
+++ b/server/types.go
@@ -1,6 +1,9 @@
 package server
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type SimRequest struct {
 	// can be none of, or one of high-prio / fast-track
@@ -13,9 +16,10 @@ type SimRequest struct {
 	Cancelled bool
 	CreatedAt time.Time
 	Tries     int
+	Context   context.Context
 }
 
-func NewSimRequest(id string, payload []byte, isHighPrio, IsFastTrack bool) *SimRequest {
+func NewSimRequest(ctx context.Context, id string, payload []byte, isHighPrio, IsFastTrack bool) *SimRequest {
 	return &SimRequest{
 		ID:          id,
 		Payload:     payload,
@@ -23,6 +27,7 @@ func NewSimRequest(id string, payload []byte, isHighPrio, IsFastTrack bool) *Sim
 		IsFastTrack: IsFastTrack,
 		ResponseC:   make(chan SimResponse, 1),
 		CreatedAt:   time.Now().UTC(),
+		Context:     ctx,
 	}
 }
 

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -102,7 +102,7 @@ func (s *Webserver) HandleQueueRequest(w http.ResponseWriter, req *http.Request)
 	// Add new sim request to queue
 	isFastTrack := req.Header.Get("X-Fast-Track") == "true"
 	isHighPrio := req.Header.Get("high_prio") == "true" || req.Header.Get("X-High-Priority") == "true"
-	simReq := NewSimRequest(reqID, body, isHighPrio, isFastTrack)
+	simReq := NewSimRequest(ctx, reqID, body, isHighPrio, isFastTrack)
 	wasAdded := s.prioQueue.Push(simReq)
 	if !wasAdded { // queue was full, job not added
 		log.Error("Couldn't add request, queue is full")


### PR DESCRIPTION
### Fix
- Previously, requests were not being canceled after being forwarded to the upstream service. This happened because the original request context was not propagated when making the upstream call. As a result, even if the client canceled the request, it would still proceed to the upstream.
- This fix ensures that the original request context is passed, allowing proper cancellation behavior.
- Upgraded `staticcheck`.
- Upgraded `github actions`.